### PR TITLE
Improve topology connections and port visibility

### DIFF
--- a/src/pages/agents/index.tsx
+++ b/src/pages/agents/index.tsx
@@ -185,10 +185,10 @@ export default function AgentPage() {
                         </TableCell>
 
                         {/* HeroUI doesn't seems to support colspan properly */}
-                        <TableCell className="hidden" />
-                        <TableCell className="hidden" />
-                        <TableCell className="hidden" />
-                        <TableCell className="hidden" />
+                        <TableCell className="hidden">{null}</TableCell>
+                        <TableCell className="hidden">{null}</TableCell>
+                        <TableCell className="hidden">{null}</TableCell>
+                        <TableCell className="hidden">{null}</TableCell>
                       </TableRow>
                     </>
                   ))


### PR DESCRIPTION
## Summary
- enrich normalized listener data with parsed connection metadata and per-agent address lookup to identify linked hosts in the topology
- draw inter-agent tunnels with port labels and show external endpoints with their port information for clearer topology chains
- populate placeholder table cells with null children to satisfy TypeScript requirements

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda89b80ec8330b40bb2890d5827ee