### PR TITLE
Integrate listeners into topology view

### DIFF
--- a/src/components/layouts/default.tsx
+++ b/src/components/layouts/default.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Link } from "@heroui/react";
 import { Navbar } from "@/components/navbar";
 
 export default function DefaultLayout({

--- a/src/components/listeners/ListenerManagementSection.tsx
+++ b/src/components/listeners/ListenerManagementSection.tsx
@@ -1,0 +1,126 @@
+import { useCallback } from "react";
+import {
+  Button,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  useDisclosure,
+} from "@heroui/react";
+import { CircleX, PlusIcon } from "lucide-react";
+import type { KeyedMutator } from "swr";
+import clsx from "clsx";
+
+import { ListenerCreationModal } from "@/pages/listeners/modal.tsx";
+import { useApi } from "@/hooks/useApi.ts";
+import type { LigoloListeners } from "@/types/listeners.ts";
+
+interface ListenerManagementSectionProps {
+  listeners?: LigoloListeners;
+  loading?: boolean;
+  mutate?: KeyedMutator<LigoloListeners>;
+  className?: string;
+  title?: string;
+}
+
+export function ListenerManagementSection({
+  listeners,
+  loading = false,
+  mutate,
+  className,
+  title = "Listeners",
+}: ListenerManagementSectionProps) {
+  const { del } = useApi();
+  const { onOpenChange, onOpen, isOpen } = useDisclosure();
+
+  const deleteListener = useCallback(
+    (listener: LigoloListeners[number]) => async () => {
+      await del("api/v1/listeners", {
+        agentId: listener.AgentID,
+        listenerId: listener.ListenerID,
+      });
+      if (mutate) {
+        await mutate();
+      }
+    },
+    [del, mutate],
+  );
+
+  const loadingState = loading ? "loading" : "idle";
+
+  return (
+    <>
+      <ListenerCreationModal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        mutate={async () => {
+          if (mutate) await mutate();
+        }}
+      />
+
+      <section className={clsx("flex flex-col gap-4", className)}>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-xl font-semibold text-default-700">{title}</h2>
+          <Button color="primary" endContent={<PlusIcon />} onPress={onOpen}>
+            Add New
+          </Button>
+        </div>
+
+        <Table aria-label="Listener list">
+          <TableHeader>
+            <TableColumn>#</TableColumn>
+            <TableColumn className="uppercase">Agent</TableColumn>
+            <TableColumn className="uppercase">Network</TableColumn>
+            <TableColumn className="uppercase">Listener Address</TableColumn>
+            <TableColumn className="uppercase">Redirect Address</TableColumn>
+            <TableColumn className="uppercase">Actions</TableColumn>
+          </TableHeader>
+          <TableBody
+            emptyContent={"No active listeners."}
+            loadingState={loadingState}
+            loadingContent={<CircularProgress aria-label="Loading..." size="sm" />}
+          >
+            <>
+              {listeners
+                ? Object.entries(listeners).map(([row, listener]) => (
+                    <TableRow key={row}>
+                      <TableCell>{listener.ListenerID}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <p className="text-bold text-sm">{listener.Agent}</p>
+                          <p className="text-bold text-sm text-default-400">
+                            {listener.RemoteAddr}
+                          </p>
+                        </div>
+                      </TableCell>
+                      <TableCell>{listener.Network}</TableCell>
+                      <TableCell>{listener.ListenerAddr}</TableCell>
+                      <TableCell>{listener.RedirectAddr}</TableCell>
+                      <TableCell>
+                        <div className="relative flex items-center gap-2">
+                          <Tooltip content="Remove listener" color="danger">
+                            <span
+                              className="cursor-pointer text-lg text-danger active:opacity-50"
+                              onClick={deleteListener(listener)}
+                            >
+                              <CircleX />
+                            </span>
+                          </Tooltip>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : null}
+            </>
+          </TableBody>
+        </Table>
+      </section>
+    </>
+  );
+}
+
+export default ListenerManagementSection;

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,10 +1,7 @@
 import clsx from "clsx";
-import { useContext } from "react";
-import { BookMarked, Github, HeartIcon, SatelliteDish } from "lucide-react";
 import { link as linkStyles } from "@heroui/theme";
 import ciber from "../assets/ciber.png";
 import {
-  Button,
   Link,
   Navbar as NextUINavbar,
   NavbarBrand,
@@ -12,17 +9,13 @@ import {
   NavbarItem,
   NavbarMenu,
   NavbarMenuItem,
-  NavbarMenuToggle
+  NavbarMenuToggle,
 } from "@heroui/react";
 
 import { siteConfig } from "@/config/site";
 import { ThemeSwitch } from "@/components/theme-switch";
-import { Logo } from "@/assets/icons/logo";
-import { AuthContext } from "@/contexts/Auth.tsx";
 
 export const Navbar = () => {
-  const { session } = useContext(AuthContext);
-
   return (
     <NextUINavbar style={{backgroundColor: '#000', opacity: '80%'}} maxWidth="xl" position="sticky">
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">

--- a/src/pages/listeners/index.tsx
+++ b/src/pages/listeners/index.tsx
@@ -1,105 +1,15 @@
-import {
-  Button,
-  CircularProgress,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableHeader,
-  TableRow,
-  Tooltip,
-  useDisclosure,
-} from "@heroui/react";
-import { CircleX, PlusIcon } from "lucide-react";
-import { ListenerCreationModal } from "@/pages/listeners/modal.tsx";
-import { useCallback } from "react";
+import { ListenerManagementSection } from "@/components/listeners/ListenerManagementSection.tsx";
 import useListeners from "@/hooks/useListeners.ts";
-import { useApi } from "@/hooks/useApi.ts";
-import { LigoloListeners } from "@/types/listeners.ts";
 
-export default function IndexPage() {
-  const { del } = useApi();
+export default function ListenersPage() {
   const { listeners, loading, mutate } = useListeners();
-  const { onOpenChange, onOpen, isOpen } = useDisclosure();
-
-  const deleteListener = useCallback(
-    (listener: LigoloListeners[number]) => async () => {
-      await del("api/v1/listeners", {
-        agentId: listener.AgentID,
-        listenerId: listener.ListenerID,
-      });
-      await mutate();
-    },
-    [mutate],
-  );
-
-  const loadingState = loading ? "loading" : "idle";
 
   return (
-    <>
-      <ListenerCreationModal
-        isOpen={isOpen}
-        onOpenChange={onOpenChange}
-        mutate={mutate}
-      ></ListenerCreationModal>
-
-      <section className="flex flex-col gap-4 md:py-10">
-        <div className="flex justify-between gap-3 items-end">
-          <Button color="primary" endContent={<PlusIcon />} onPress={onOpen}>
-            Add New
-          </Button>
-        </div>
-        <Table aria-label="Listener list">
-          <TableHeader>
-            <TableColumn>#</TableColumn>
-            <TableColumn className="uppercase">Agent</TableColumn>
-            <TableColumn className="uppercase">Network</TableColumn>
-            <TableColumn className="uppercase">Listener Address</TableColumn>
-            <TableColumn className="uppercase">Redirect Address</TableColumn>
-            <TableColumn className={"uppercase"}>Actions</TableColumn>
-          </TableHeader>
-          <TableBody
-            emptyContent={"No active listeners."}
-            loadingState={loadingState}
-            loadingContent={
-              <CircularProgress aria-label="Loading..." size="sm" />
-            }
-          >
-            <>
-              {listeners
-                ? Object.entries(listeners).map(([row, listener]) => (
-                    <TableRow key={row}>
-                      <TableCell>{listener.ListenerID}</TableCell>
-                      <TableCell>
-                        <div className="flex flex-col">
-                          <p className="text-bold text-sm">{listener.Agent}</p>
-                          <p className="text-bold text-sm text-default-400">
-                            {listener.RemoteAddr}
-                          </p>
-                        </div>
-                      </TableCell>
-                      <TableCell>{listener.Network}</TableCell>
-                      <TableCell>{listener.ListenerAddr}</TableCell>
-                      <TableCell>{listener.RedirectAddr}</TableCell>
-                      <TableCell>
-                        <div className="relative flex items-center gap-2">
-                          <Tooltip content="Remove listener" color={"danger"}>
-                            <span
-                              className="text-lg text-danger cursor-pointer active:opacity-50"
-                              onClick={deleteListener(listener)}
-                            >
-                              <CircleX />
-                            </span>
-                          </Tooltip>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))
-                : null}
-            </>
-          </TableBody>
-        </Table>
-      </section>
-    </>
+    <ListenerManagementSection
+      listeners={listeners}
+      loading={loading}
+      mutate={mutate}
+      className="py-6 md:py-10"
+    />
   );
 }

--- a/src/pages/listeners/modal.tsx
+++ b/src/pages/listeners/modal.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  PointerEvent as ReactPointerEvent,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import useAgents from "@/hooks/useAgents.ts";
 import {
   Button,
@@ -13,6 +20,7 @@ import {
   SelectItem,
 } from "@heroui/react";
 import { EthernetPort } from "lucide-react";
+import { useDragControls } from "framer-motion";
 import { useApi } from "@/hooks/useApi.ts";
 import { LigoloAgent } from "@/types/agents.ts";
 import ErrorContext from "@/contexts/Error.tsx";
@@ -52,6 +60,7 @@ export function ListenerCreationModal({
   const { agents } = useAgents();
   const { setError } = useContext(ErrorContext);
   const [formErrors, setFormErrors] = useState({});
+  const dragControls = useDragControls();
 
   useEffect(() => {
     setSelectedAgent(agentId);
@@ -125,12 +134,34 @@ export function ListenerCreationModal({
     [mutate, selectedAgent, listenerAddr, redirectAddr, listenerProtocol],
   );
 
+  const handleHeaderPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      dragControls.start(event);
+    },
+    [dragControls],
+  );
+
   return (
-    <Modal isOpen={isOpen} placement="top-center" onOpenChange={onOpenChange}>
+    <Modal
+      isOpen={isOpen}
+      placement="top-center"
+      onOpenChange={onOpenChange}
+      motionProps={{
+        drag: true,
+        dragControls,
+        dragListener: false,
+        dragMomentum: false,
+      }}
+    >
       <ModalContent>
         {(onClose) => (
           <>
-            <ModalHeader className="flex flex-col gap-1">
+            <ModalHeader
+              className="flex flex-col gap-1 cursor-move select-none active:cursor-grabbing"
+              onPointerDown={handleHeaderPointerDown}
+            >
               Add a new listener
             </ModalHeader>
             <ModalBody>

--- a/src/pages/topology/index.original.tsx
+++ b/src/pages/topology/index.original.tsx
@@ -80,7 +80,7 @@ export default function Topology() {
     );
 
     // Agents
-    Object.entries(agents ?? {}).forEach(([agentId, agent], idx) => {
+    Object.entries(agents ?? {}).forEach(([agentId, agent]) => {
       const ips: string[] = [];
       asArray(agent?.Network).forEach((n: any) => ips.push(...uniqueIPv4s(n?.Addresses)));
       const hasToProxy = listenerList.some((l: any) => {

--- a/src/pages/topology/index.tsx
+++ b/src/pages/topology/index.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
 import { useEffect, useMemo, useRef, useState } from "react";
+
+import { ListenerManagementSection } from "@/components/listeners/ListenerManagementSection.tsx";
 import useAgents from "@/hooks/useAgents.ts";
 import useListeners from "@/hooks/useListeners.ts";
 import type { LigoloAgent } from "@/types/agents.ts";
@@ -113,8 +115,15 @@ function createPortPin(
 // componente ---------------------------------------------------------------
 export default function Topology() {
   const { agents } = useAgents();
-  const { listeners } = useListeners();
-  const listenerList = asArray<Partial<Listener>>(listeners);
+  const {
+    listeners,
+    loading: listenersLoading,
+    mutate: mutateListeners,
+  } = useListeners();
+  const listenerList = useMemo(
+    () => asArray<Partial<Listener>>(listeners),
+    [listeners],
+  );
 
   // ip -> agentId
   const ipToAgent = useMemo(() => {
@@ -335,12 +344,27 @@ export default function Topology() {
 
   // UI --------------------------------------------------------------------
   return (
-    <div  className="p-8">
-      <div style={{ display: "flex", alignItems: "center" }}>
-        <h1 className="text-2xl font-semibold mb-6">Topologia</h1>
+    <div className="flex flex-col gap-8 py-6 pb-12">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold text-slate-900">Topologia</h1>
+        <p className="text-sm text-slate-500">
+          Gerencie listeners enquanto visualiza a topologia da rede em tempo real.
+        </p>
       </div>
 
-      <div style={{minHeight:'750px'}} ref={stageRef} className="relative w-full h-[460px] rounded-xl border bg-white">
+      <ListenerManagementSection
+        listeners={listeners}
+        loading={listenersLoading}
+        mutate={mutateListeners}
+        className="gap-6"
+      />
+
+      <section className="flex flex-col gap-3">
+        <div
+          ref={stageRef}
+          className="relative w-full min-h-[460px] rounded-xl border bg-white shadow-sm"
+          style={{ minHeight: 520, height: "clamp(420px, 65vh, 720px)" }}
+        >
         {/* conexões */}
         <svg className="absolute inset-0 h-full w-full pointer-events-none">
           {connections.map((conn) => (
@@ -422,11 +446,13 @@ export default function Topology() {
             </div>
           </div>
         ))}
-      </div>
+        </div>
 
-      <p className="text-xs text-slate-500">
-        Dica: arraste as caixas livremente para reorganizar — os túneis paralelos se ajustam automaticamente.
-      </p>
+        <p className="text-xs text-slate-500">
+          Dica: arraste as caixas livremente para reorganizar — os túneis paralelos se ajustam
+          automaticamente.
+        </p>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable listener management section and render it above the topology diagram
- enable dragging for the listener creation modal to keep the topology visible while editing
- reuse the shared section on the listeners page and clean up related TypeScript warnings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2aaa6496c8330884e14b6e404499e