### PR TITLE
Fix listener modal dragging behavior

### DIFF
--- a/src/pages/listeners/modal.tsx
+++ b/src/pages/listeners/modal.tsx
@@ -20,7 +20,7 @@ import {
   SelectItem,
 } from "@heroui/react";
 import { EthernetPort } from "lucide-react";
-import { motion, useDragControls } from "framer-motion";
+import { useDragControls } from "framer-motion";
 import { useApi } from "@/hooks/useApi.ts";
 import { LigoloAgent } from "@/types/agents.ts";
 import ErrorContext from "@/contexts/Error.tsx";
@@ -148,16 +148,16 @@ export function ListenerCreationModal({
       isOpen={isOpen}
       placement="top-center"
       onOpenChange={onOpenChange}
+      motionProps={{
+        drag: true,
+        dragControls,
+        dragListener: false,
+        dragMomentum: false,
+      }}
     >
       <ModalContent>
         {(onClose) => (
-          <motion.div
-            drag
-            dragControls={dragControls}
-            dragListener={false}
-            dragMomentum={false}
-            className="pointer-events-auto"
-          >
+          <>
             <ModalHeader
               className="flex flex-col gap-1 cursor-move select-none active:cursor-grabbing"
               onPointerDown={handleHeaderPointerDown}
@@ -278,7 +278,7 @@ export function ListenerCreationModal({
                 Add listener
               </Button>
             </ModalFooter>
-          </motion.div>
+          </>
         )}
       </ModalContent>
     </Modal>


### PR DESCRIPTION
## Summary
- ensure the listener modal passes drag controls through `motionProps` so the entire dialog moves when dragged
- remove the extra motion wrapper now that the modal content handles dragging

## Testing
- `npm run lint` *(fails: existing unused imports in `src/components/navbar.tsx`)*
- `npm run build` *(fails: existing unused imports in `src/components/navbar.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c345d5748330b57f381817b64596