### PR TITLE
Fix listener table ordering

### DIFF
--- a/src/types/listeners.ts
+++ b/src/types/listeners.ts
@@ -1,4 +1,6 @@
-export type LigoloListeners = Listener[]
+export type ListenerMap = Record<string, Listener>;
+
+export type LigoloListeners = Listener[] | ListenerMap;
 
 export interface Listener {
     ListenerID: number


### PR DESCRIPTION
## Summary
- normalize listener collections before rendering and sort them deterministically by ID and agent name
- update listener types to cover both array and map API responses used by the UI

## Testing
- npm run build *(fails: src/pages/login.tsx unused imports pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68da6d105428833097772be2721c3c3b