### PR TITLE
Allow page scrolling while listener modal is open

### DIFF
--- a/src/pages/listeners/modal.tsx
+++ b/src/pages/listeners/modal.tsx
@@ -257,6 +257,7 @@ export function ListenerCreationModal({
       isOpen={isOpen}
       placement="top-center"
       onOpenChange={onOpenChange}
+      shouldBlockScroll={false}
       classNames={{ wrapper: "listener-creation-modal-wrapper" }}
     >
       <ModalContent>


### PR DESCRIPTION
## Summary
- allow the listener creation modal to avoid blocking background page scrolling so agents remain visible while configuring listeners

## Testing
- npm run lint *(fails: pre-existing lint errors in src/pages/login.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe3cf12648330bda6c109da136844