### PR TITLE
Persist topology layout and client-side theme state

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,10 +1,8 @@
 import clsx from "clsx";
 import { useCallback, useContext } from "react";
-import { link as linkStyles } from "@heroui/theme";
 import ciber from "../assets/ciber.png";
 import {
   Button,
-  Link,
   Navbar as NextUINavbar,
   NavbarBrand,
   NavbarContent,
@@ -17,7 +15,7 @@ import {
 import { siteConfig } from "@/config/site";
 import { ThemeSwitch } from "@/components/theme-switch";
 import { AuthContext } from "@/contexts/Auth.tsx";
-import { useNavigate } from "react-router-dom";
+import { Link as RouterLink, NavLink, useNavigate } from "react-router-dom";
 
 export const Navbar = () => {
   const { session, logOut } = useContext(AuthContext);
@@ -32,29 +30,26 @@ export const Navbar = () => {
     <NextUINavbar style={{backgroundColor: '#000', opacity: '80%'}} maxWidth="xl" position="sticky">
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
         <NavbarBrand className="gap-3 max-w-fit">
-          <Link
-            className="flex justify-start items-center gap-1"
-            color="foreground"
-            href="/"
-          >
-        <img style={{ marginLeft: 10 }} src={ciber} alt="Ciber" className="h-12 object-contain" />
+          <RouterLink className="flex items-center justify-start gap-1" to="/">
+            <img style={{ marginLeft: 10 }} src={ciber} alt="Ciber" className="h-12 object-contain" />
             <p style={{color: '#fff'}} className="font-bold text-inherit">Ligolo-ng Tunnel Manager</p>
-          </Link>
+          </RouterLink>
         </NavbarBrand>
         <div className="hidden lg:flex gap-4 justify-start ml-2">
           {siteConfig.navItems.map((item) => (
             <NavbarItem key={item.href}>
-              <Link
-              style={{color: '#ffcc29', fontWeight: 'bold'}}
-                className={clsx(
-                  linkStyles({ color: "foreground" }),
-                  "data-[active=true]:text-primary data-[active=true]:font-medium"
-                )}
-                color="foreground"
-                href={item.href}
+              <NavLink
+                className={({ isActive }) =>
+                  clsx(
+                    "font-bold text-[#ffcc29] transition-opacity",
+                    isActive ? "opacity-100" : "opacity-80 hover:opacity-100"
+                  )
+                }
+                end={item.href === "/"}
+                to={item.href}
               >
                 {item.label}
-              </Link>
+              </NavLink>
             </NavbarItem>
           ))}
         </div>
@@ -86,9 +81,18 @@ export const Navbar = () => {
         <div className="mx-4 mt-2 flex flex-col gap-2">
           {siteConfig.navItems.map((item, index) => (
             <NavbarMenuItem key={`${item}-${index}`}>
-              <Link color={"foreground"} href={item.href} size="lg">
+              <NavLink
+                className={({ isActive }) =>
+                  clsx(
+                    "text-lg font-bold text-[#ffcc29] transition-opacity",
+                    isActive ? "opacity-100" : "opacity-80 hover:opacity-100"
+                  )
+                }
+                end={item.href === "/"}
+                to={item.href}
+              >
                 {item.label}
-              </Link>
+              </NavLink>
             </NavbarMenuItem>
           ))}
           {session && (

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
 import { useCallback, useContext, useState } from "react";
-import { Minus } from "lucide-react";
-import { Logo } from "@/assets/icons/logo.tsx";
 import { ThemeSwitch } from "@/components/theme-switch.tsx";
 import { AuthContext } from "@/contexts/Auth.tsx";
 import ErrorContext from "@/contexts/Error.tsx";


### PR DESCRIPTION
## Summary
- replace navbar anchors with React Router navigation so theme state survives route changes
- lay out topology proxies and agents in separate columns and persist manual node placement in local storage
- remove unused imports from the login page to keep the TypeScript build clean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbeb9f10a4833088a8f1080620d630