### PR TITLE
Add listener management filters and align navbar width

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -27,7 +27,15 @@ export const Navbar = () => {
   }, [logOut, navigate]);
 
   return (
-    <NextUINavbar style={{backgroundColor: '#000', opacity: '80%'}} maxWidth="xl" position="sticky">
+    <NextUINavbar
+      style={{ backgroundColor: "#000", opacity: "80%" }}
+      maxWidth="full"
+      position="sticky"
+      classNames={{
+        base: "mx-auto w-full px-0",
+        wrapper: "mx-auto w-full max-w-7xl px-6",
+      }}
+    >
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
         <NavbarBrand className="gap-3 max-w-fit">
           <RouterLink className="flex items-center justify-start gap-1" to="/">


### PR DESCRIPTION
## Summary
- add filtering, sorting and counter controls to the listener management table for clearer tunnel visibility
- show sequential numbering in the listener list and keep actions intact
- align the navbar width with the enlarged page layout for consistent spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc11504a848330b7ee515f22231253