### PR TITLE
Fix vertical tunnel pin spacing

### DIFF
--- a/src/pages/topology/index.tsx
+++ b/src/pages/topology/index.tsx
@@ -407,13 +407,6 @@ export default function Topology() {
           const offset = index * PIN_STACK_GAP;
           pin.y += side === "top" ? -offset : offset;
         });
-      } else if (side === "left" || side === "right") {
-        group.sort((a, b) => a.y - b.y);
-        group.forEach((pin, index) => {
-          if (index === 0) return;
-          const offset = index * PIN_STACK_GAP;
-          pin.x += side === "left" ? -offset : offset;
-        });
       }
     });
 


### PR DESCRIPTION
## Summary
- only apply stacking offsets to topology port pins on vertical sides so horizontal tunnels render as before

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc18e017e48330a3ad1e51a1ca5350