### PR TITLE
Fix tooltip usage in topology dropdown trigger

### DIFF
--- a/src/pages/topology/index.tsx
+++ b/src/pages/topology/index.tsx
@@ -825,36 +825,38 @@ function AgentTunnelPanel({
             </Button>
           </Tooltip>
         ) : (
-          <Dropdown>
-            <DropdownTrigger>
-              <Tooltip content="Iniciar o tunelamento" color="primary">
-                <Button
-                  size="sm"
-                  color="primary"
-                  variant="flat"
-                  startContent={<Power size={16} />}
+          <Tooltip content="Iniciar o tunelamento" color="primary">
+            <div className="inline-flex">
+              <Dropdown>
+                <DropdownTrigger>
+                  <Button
+                    size="sm"
+                    color="primary"
+                    variant="flat"
+                    startContent={<Power size={16} />}
+                  >
+                    Tunelar
+                  </Button>
+                </DropdownTrigger>
+                <DropdownMenu
+                  aria-label="Opções de tunelamento"
+                  items={dropdownItems}
+                  onAction={handleDropdownAction}
                 >
-                  Tunelar
-                </Button>
-              </Tooltip>
-            </DropdownTrigger>
-            <DropdownMenu
-              aria-label="Opções de tunelamento"
-              items={dropdownItems}
-              onAction={handleDropdownAction}
-            >
-              {(item) => (
-                <DropdownItem
-                  key={item.key}
-                  startContent={item.icon}
-                  description={item.description}
-                  isDisabled={item.disabled}
-                >
-                  {item.label}
-                </DropdownItem>
-              )}
-            </DropdownMenu>
-          </Dropdown>
+                  {(item) => (
+                    <DropdownItem
+                      key={item.key}
+                      startContent={item.icon}
+                      description={item.description}
+                      isDisabled={item.disabled}
+                    >
+                      {item.label}
+                    </DropdownItem>
+                  )}
+                </DropdownMenu>
+              </Dropdown>
+            </div>
+          </Tooltip>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- wrap the topology tunnel action dropdown with an inline container so the tooltip no longer becomes the dropdown trigger element
- keep the dropdown trigger as the button to avoid ResizeObserver errors when opening the menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6461bd408330b4c62a4f3d0d206b