### PR TITLE
Add all interfaces option in listener modal

### DIFF
--- a/src/pages/listeners/modal.tsx
+++ b/src/pages/listeners/modal.tsx
@@ -300,6 +300,21 @@ export function ListenerCreationModal({
                       IPv4 disponíveis
                     </p>
                     <div className="flex flex-col gap-2">
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleSelectIp("0.0.0.0")}
+                          aria-pressed={listenerIp === "0.0.0.0"}
+                          className={clsx(
+                            "rounded-md border px-2 py-0.5 text-[11px] transition-colors focus:outline-none",
+                            listenerIp === "0.0.0.0"
+                              ? "border-primary-400 bg-primary-100 text-primary"
+                              : "border-default-200 bg-white text-default-600 hover:border-default-300 hover:bg-default-100",
+                          )}
+                        >
+                          Todas as interfaces
+                        </button>
+                      </div>
                       {agentInterfaces.length ? (
                         agentInterfaces.map((iface) => (
                           <div key={iface.key} className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- add an "Todas as interfaces" quick action button to the listener creation modal
- allow users to fill the listener address with 0.0.0.0 without picking a specific interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2909ce5b08330ae28ade14e5dbdc9